### PR TITLE
Fix deprecated spec syntax

### DIFF
--- a/spec/log_weasel/log_weasel_spec.rb
+++ b/spec/log_weasel/log_weasel_spec.rb
@@ -8,7 +8,7 @@ describe LogWeasel do
       LogWeasel.configure do |config|
         config.key = "KEY"
       end
-      LogWeasel.config.key.should == "KEY"
+      expect(LogWeasel.config.key).to eq "KEY"
     end
   end
 

--- a/spec/log_weasel/transaction_spec.rb
+++ b/spec/log_weasel/transaction_spec.rb
@@ -34,7 +34,7 @@ describe LogWeasel::Transaction do
 
     it "creates a transaction id with a key" do
       id = LogWeasel::Transaction.create "KEY"
-      expect(id).to eq  "KEY-94b2"
+      expect(id).to eq "KEY-94b2"
       expect(LogWeasel::Transaction.id).to eq id
     end
 

--- a/spec/log_weasel/transaction_spec.rb
+++ b/spec/log_weasel/transaction_spec.rb
@@ -6,7 +6,7 @@ describe LogWeasel::Transaction do
   describe ".id" do
 
     it "is nil if not created" do
-      LogWeasel::Transaction.id.should be_nil
+      expect(LogWeasel::Transaction.id).to be_nil
     end
 
   end
@@ -17,7 +17,7 @@ describe LogWeasel::Transaction do
     end
 
     it "sets the id" do
-      LogWeasel::Transaction.id.should == "1234"
+      expect(LogWeasel::Transaction.id).to eq "1234"
     end
 
   end
@@ -29,13 +29,13 @@ describe LogWeasel::Transaction do
 
     it "creates a transaction id with no key" do
       id = LogWeasel::Transaction.create
-      id.should == "94b2"
+      expect(id).to eq "94b2"
     end
 
     it "creates a transaction id with a key" do
       id = LogWeasel::Transaction.create "KEY"
-      id.should == "KEY-94b2"
-      LogWeasel::Transaction.id.should == id
+      expect(id).to eq  "KEY-94b2"
+      expect(LogWeasel::Transaction.id).to eq id
     end
 
   end
@@ -47,7 +47,7 @@ describe LogWeasel::Transaction do
 
     it "removes transaction id" do
       LogWeasel::Transaction.destroy
-      LogWeasel::Transaction.id.should be_nil
+      expect(LogWeasel::Transaction.id).to be_nil
     end
   end
 end


### PR DESCRIPTION
- Change `x.should == y` to `expect(x).to eq y`, etc.