### PR TITLE
Removed the Active Support Dependency

### DIFF
--- a/lib/log_weasel/version.rb
+++ b/lib/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module Log
   module Weasel
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/log_weasel.gemspec
+++ b/log_weasel.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("mocha")
   s.add_development_dependency("no_soup_for_you")
 
-  # s.add_dependency("activesupport", "~> 4.1.1")
-  s.add_dependency("activesupport")
+  s.add_dependency("activesupport", "~> 4.1")
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/log_weasel.gemspec
+++ b/log_weasel.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency("mocha")
   s.add_development_dependency("no_soup_for_you")
 
-  s.add_dependency("activesupport", "~> 4.1.1")
+  # s.add_dependency("activesupport", "~> 4.1.1")
+  s.add_dependency("activesupport")
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
We did this because it was impossible to build with our projects due to conflicts in the dependencies.